### PR TITLE
[ENG-3028] Implement librdkafka-compatible partitioning

### DIFF
--- a/builders.go
+++ b/builders.go
@@ -15,6 +15,8 @@ func DefaultProducerBuilder(brokers []string, clientID string, hasher func() has
 	config.ClientID = clientID
 	config.Producer.Partitioner = sarama.NewCustomPartitioner(
 		sarama.WithCustomHashFunction(hasher),
+		// Treat the hashed value as unsigned for compatibility with the way
+		// librdkafka does partitioning.
 		sarama.WithHashUnsigned(),
 	)
 	return NewProducer(brokers, &config)
@@ -26,6 +28,8 @@ func ProducerBuilderWithConfig(config *sarama.Config) ProducerBuilder {
 		config.ClientID = clientID
 		config.Producer.Partitioner = sarama.NewCustomPartitioner(
 			sarama.WithCustomHashFunction(hasher),
+			// Treat the hashed value as unsigned for compatibility with the way
+			// librdkafka does partitioning.
 			sarama.WithHashUnsigned(),
 		)
 		return NewProducer(brokers, config)

--- a/builders.go
+++ b/builders.go
@@ -13,7 +13,10 @@ type ProducerBuilder func(brokers []string, clientID string, hasher func() hash.
 func DefaultProducerBuilder(brokers []string, clientID string, hasher func() hash.Hash32) (Producer, error) {
 	config := globalConfig
 	config.ClientID = clientID
-	config.Producer.Partitioner = sarama.NewCustomHashPartitioner(hasher)
+	config.Producer.Partitioner = sarama.NewCustomPartitioner(
+		sarama.WithCustomHashFunction(hasher),
+		sarama.WithHashUnsigned(),
+	)
 	return NewProducer(brokers, &config)
 }
 
@@ -21,7 +24,10 @@ func DefaultProducerBuilder(brokers []string, clientID string, hasher func() has
 func ProducerBuilderWithConfig(config *sarama.Config) ProducerBuilder {
 	return func(brokers []string, clientID string, hasher func() hash.Hash32) (Producer, error) {
 		config.ClientID = clientID
-		config.Producer.Partitioner = sarama.NewCustomHashPartitioner(hasher)
+		config.Producer.Partitioner = sarama.NewCustomPartitioner(
+			sarama.WithCustomHashFunction(hasher),
+			sarama.WithHashUnsigned(),
+		)
 		return NewProducer(brokers, config)
 	}
 }

--- a/view.go
+++ b/view.go
@@ -304,14 +304,12 @@ func (v *View) hash(key string) (int32, error) {
 	if err != nil {
 		return -1, err
 	}
-	hash := int32(hasher.Sum32())
-	if hash < 0 {
-		hash = -hash
-	}
+
 	if len(v.partitions) == 0 {
 		return 0, errors.New("no partitions found")
 	}
-	return hash % int32(len(v.partitions)), nil
+
+	return int32(hasher.Sum32() % uint32(len(v.partitions))), nil
 }
 
 func (v *View) find(key string) (*PartitionTable, error) {

--- a/view.go
+++ b/view.go
@@ -309,6 +309,9 @@ func (v *View) hash(key string) (int32, error) {
 		return 0, errors.New("no partitions found")
 	}
 
+	// Treat the hashed value as unsigned before converting it modulo the number
+	// of partitions to a signed integer. This is for compatibility with the way
+	// librdkafka does partitioning.
 	return int32(hasher.Sum32() % uint32(len(v.partitions))), nil
 }
 


### PR DESCRIPTION
### Summary of changes

In this PR, I:

- Implemented compatibility with librdkafka's partitioning scheme.
  - Why? The producers that write to the processor's input topics all either are librdkafka-based or use a partitioner that is compatible with librdkafka's.  To maintain the property that the input topics are copartitioned with the group table topic, the processor producer needs to use the same partitioning scheme. When looking up the state for a key, the view needs to know in which partition to look for the key.
  - Refer to how [`sarama.WithHashUnsigned`](https://pkg.go.dev/github.com/IBM/sarama#WithHashUnsigned) is implemented and used to understand librdkafka's partitioning scheme.

### Testing

- [x] Added a unit test to ensure compatibility

### Open questions

- How can we contribute this change back to the upstream library?
